### PR TITLE
fix logic bug in notifications

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,7 +159,7 @@ class $modify(EditorUIHook, EditorUI) {
     void showNotification(std::string text, bool error) {
         int mode = m_fields->notificationMode;
         if (mode == 0) return;
-        if (mode == 1 && error) return;
+        if (mode == 1 && !error) return;
         Notification::create(
             text, error ? NotificationIcon::Error : NotificationIcon::Success
         )->show();


### PR DESCRIPTION
This pull request is to fix a serious logical error in the logic for creating notifications.
Notifications are meant to have 3 different modes, those being: all notifications, only errors and no notifications.
Through a missing not operator it has happened that the "only errors" mode actually is a "everything except errors" mode.

This is a serious issue which i believe should be addressed as quickly as possible.

Enough serious talk, stay silly :3